### PR TITLE
Change infos type name images

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -618,10 +618,10 @@ static NSString *const kShareOptionUrl = @"url";
 
   // with WhatsApp, we can share an image OR text+url.. image wins if set
   if (image != nil) {
-    NSString * savePath = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents/whatsAppTmp.wai"];
+    NSString * savePath = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents/whatsAppTmp.jpeg"];
     [UIImageJPEGRepresentation(image, 1.0) writeToFile:savePath atomically:YES];
     _documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:[NSURL fileURLWithPath:savePath]];
-    _documentInteractionController.UTI = @"net.whatsapp.image";
+    _documentInteractionController.UTI = @"public.image";
     _documentInteractionController.delegate = self;
     _command = command;
     [_documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:self.viewController.view animated: YES];


### PR DESCRIPTION
IOS 10.3.3 Errors on share images

WhatsApp share - exibia duas opções para share da imagem, sendo que uma delas funcionava corretamente e a outra perdia o nome do arquivo e mantém o nove temp.way.
Em versões <= 10.1.1 funcionava normalmente,mas a partir da 10.3.3 acontecia esse erro que foi corrigido alterando o arquivo do plugin!